### PR TITLE
Fix screenshots bug

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -688,7 +688,7 @@ exports.getScreenshot = async function (captureOptions = {}, returnBinary = fals
  *    @property {boolean} fromSurface - Capture the screenshot from the surface, rather than the view. Defaults to false. EXPERIMENTAL
  * @return {string} - Binary or Base64 string with the image data
  */
-exports.saveScreenshot = async function (fileName = `screenshot-${Date.now()}`, captureOptions) {
+exports.saveScreenshot = async function (fileName = `screenshot-${Date.now()}`, captureOptions = {}) {
   debug(`:: saveScreenshot => Saving a screenshot of the page...`)
   browserIsInitialized.call(this)
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -23,6 +23,7 @@ const { sleep } = require('./util')
 
 const defaultOptions = {
   headless: true,
+  disableGPU: true,
   launchChrome: true, // If false, only connects CDP to the Chrome instance in host:port
   chrome: {
     host: 'localhost',
@@ -59,6 +60,7 @@ class HeadlessChrome extends EventEmitter {
       // Launch a new Chrome instance and update the instance port
       this.chromeInstance = await _launchChrome({
         headless: this.options.headless,
+        disableGPU: this.options.disableGPU,
         port: this.options.chrome.port,
         launchAttempts: this.options.chrome.launchAttempts
       })
@@ -132,13 +134,13 @@ module.exports = HeadlessChrome
  *    @property {number} port - The port used by the Chrome instance
  *    @property {async fn} kill - Fn to kill the Chrome instance
  */
-async function _launchChrome ({ headless = true, port = 0, launchAttempts }) {
+async function _launchChrome ({ headless = true, disableGPU = true, port = 0, launchAttempts }) {
   debug(`Launching Chrome instance. Headless: ${headless === true ? 'YES' : 'NO'}`)
 
   const chromeOptions = {
     port: port,
     chromeFlags: [
-      '--disable-gpu',
+      disableGPU ? '--disable-gpu' : '',
       '--enable-logging',
       headless ? '--headless' : ''
     ]


### PR DESCRIPTION
Before, calling saveScreenshot() would fail. You had to pass and empty options object.

BTW thanks for making this module. It's the nicest headless Chrome API by far!

@LucianoGanga 