### PR TITLE
Error if no format input

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -691,8 +691,7 @@ exports.getScreenshot = async function (captureOptions = {}, returnBinary = fals
 exports.saveScreenshot = async function (fileName = `screenshot-${Date.now()}`, captureOptions) {
   debug(`:: saveScreenshot => Saving a screenshot of the page...`)
   browserIsInitialized.call(this)
-
-  await fs.writeFile(`${fileName}.${captureOptions.format || 'png'}`, await this.getScreenshot(captureOptions), 'base64')
+  await fs.writeFile(`${fileName}`, await this.getScreenshot(captureOptions), 'base64')
   debug(`:: saveScreenshot => Screenshot saved!`)
 }
 


### PR DESCRIPTION
Couple concerns - filename given usually would include format, so preferably to let user append their own format prefix. Secondly, as given, if no format passed in, there's no default set so line 694 errors out as captureOptions.format does not exist.