### PR TITLE
Add resize fullscreen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Once you have the browser instance, you can call the methods to interact with it
 ### `browser.getScreenshot()`
 ### `browser.saveScreenshot()`
 ### `browser.getFrames()`
+### `browser.resizeFullScreen()`
 ### `browser.handleDialog()`
 ### `browser.post()`
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -727,6 +727,23 @@ exports.getFrames = async function () {
 }
 
 /**
+ * Resize viewports of the page to full screen size
+ */
+exports.resizeFullScreen = async function () {
+  debug(`:: resizeFullScreen => Resizing viewport to full screen size`)
+  const {DOM, Emulation} = this.client
+  const {root: {nodeId: documentNodeId}} = await DOM.getDocument()
+  const {nodeId: bodyNodeId} = await DOM.querySelector({
+    selector: 'body',
+    nodeId: documentNodeId,
+  })
+  const viewportWidth = await this.options.deviceMetrics.width
+  const {model: {height}} = await DOM.getBoxModel({nodeId: bodyNodeId})
+  await Emulation.setVisibleSize({width: viewportWidth, height: height})
+  await Emulation.forceViewport({x: 0, y: 0, scale: 1})
+}
+
+/**
  * Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload)
  * @param {boolean} [accept=true] - Whether to accept or dismiss the dialog
  * @param {string} [promptText] - The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog.


### PR DESCRIPTION
Hello @LucianoGanga!
I'm being helped by this module, thanks!

I think it would be useful if you have the option to take full size screen shots.

Ref: https://medium.com/@dschnr/using-headless-chrome-as-an-automated-screenshot-tool-4b07dffba79a

like this.

```javascript:example.js
async function navigateWebsite() {
  await browser.init()
  await browser.goTo('https://www.npmjs.com/package/simple-headless-chrome')
  await browser.resizeFullScreen() // this
  await browser.saveScreenshot('./shc.png' )
}
```

![shc png](https://user-images.githubusercontent.com/12286331/27418737-0788aeba-5758-11e7-8d83-c574adfa7a91.png)