### PR TITLE
Added method for setting listener to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Once you have the browser instance, you can call the methods to interact with it
 ### `browser.resizeFullScreen()`
 ### `browser.handleDialog()`
 ### `browser.post()`
+### `browser.onConsole()`
 
 # Example
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -440,6 +440,21 @@ exports.wait = async function (time) {
   return sleep(time)
 }
 
+
+/**
+ * Binding callback to handle console messages
+ *
+ * @param listener is a callback for handling console message
+ *
+ */
+exports.onConsole = async function(listener){
+	debug(`:: onConsole => Binding new listener to console`)
+	browserIsInitialized.call(this);
+
+	this.on('onConsoleMessage', listener)
+}
+
+
 /**
  * Waits for a page to finish loading. Throws error after timeout
  * @param {number} timeout - The timeout in ms. (Default: "loadPageTimeout" property in the browser instance options)

--- a/lib/setupHandlers.js
+++ b/lib/setupHandlers.js
@@ -6,6 +6,7 @@ module.exports = async function setupHandlers () {
   debug(`Setting up handlers...`)
   const Network = this.client.Network
   const Page = this.client.Page
+  const Log = this.client.Log
 
   /**
    * Prepare the browser console events, if needed
@@ -26,6 +27,16 @@ module.exports = async function setupHandlers () {
     debug(`-- Network.requestWillBeSent: `, ...params)
     this.emit('requestWillBeSent', ...params)
   })
+
+  /**
+  * If api method type is log then emit onConsoleMessage event;
+  */
+  this.client.Runtime.consoleAPICalled((...params) => {
+    debug(`-- Added something in console `, ...params)
+    if(params[0].type === 'log')
+      this.emit('onConsoleMessage', params[0].args)
+  })
+  this.client.Runtime.enable()
 
   Page.loadEventFired((...params) => {
     debug('-- Page.loadEventFired \r\n', ...params)


### PR DESCRIPTION
onConsole is method for setting listener to console. Currently I'm migrating from PhantomJS to chrome headless by using your module. I need such method. Hope that it will be useful for somebody else, also.