### PR TITLE
Timeout in Promise.race

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -41,7 +41,11 @@ exports.promiseTimeout = function (promise, timeout) {
 
    return Promise.race([
      new Promise((resolve, reject) => {
-       timer = setTimeout(reject, timeout);
+       timer = setTimeout(()=>{
+         const err = new Error('[Headless Chrome] Timeout after ' + timeout + ' ms')
+         err.code = 'TIMEOUT'
+         throw err
+       }, timeout);
        return timer;
      }),
      promise.then((value) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -34,11 +34,21 @@ const sleep = exports.sleep = function (delay) {
  * @param {number} timeout - The timeout time, in ms
  */
 exports.promiseTimeout = function (promise, timeout) {
-  return Promise.race([promise, sleep(timeout).then(() => {
-    const err = new Error('[Headless Chrome] Timeout after ' + timeout + ' ms')
-    err.code = 'TIMEOUT'
-    throw err
-  })])
+  // https://stackoverflow.com/questions/30936824/what-is-the-best-general-practice-to-timeout-a-function-in-promise
+  // Handles the timeout internally, clearing it when the promise resolves.
+  // It prevents the library to hang until the timeout is resolved
+  let timer = null;
+
+   return Promise.race([
+     new Promise((resolve, reject) => {
+       timer = setTimeout(reject, timeout);
+       return timer;
+     }),
+     promise.then((value) => {
+       clearTimeout(timer);
+       return value;
+     })
+   ]);
 }
 
 /**


### PR DESCRIPTION
Handles the timeout interval inside of the promiseTimeout function in util.js

Prevents the scripts to wait for the timeout to resolve before exiting.

Should be backward compatible. Just tested, it works fine.