### PR TITLE
Add 'no sandbox' argument to Chrome

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -70,9 +70,9 @@ class HeadlessChrome extends EventEmitter {
         disableGPU: this.options.disableGPU,
         noSandbox: this.options.chrome.noSandbox,
         port: this.options.chrome.port,
-        userDataDir: this.options.chrome.userDataDir,        
+        userDataDir: this.options.chrome.userDataDir,
         launchAttempts: this.options.chrome.launchAttempts,
-        handleSIGINT: this.options.chrome.handleSIGINT,
+        handleSIGINT: this.options.chrome.handleSIGINT
       })
       this.port = this.chromeInstance.port
     }

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -68,11 +68,11 @@ class HeadlessChrome extends EventEmitter {
       this.chromeInstance = await _launchChrome({
         headless: this.options.headless,
         disableGPU: this.options.disableGPU,
+        noSandbox: this.options.chrome.noSandbox,
         port: this.options.chrome.port,
         userDataDir: this.options.chrome.userDataDir,        
         launchAttempts: this.options.chrome.launchAttempts,
         handleSIGINT: this.options.chrome.handleSIGINT,
-        noSandbox: this.options.chrome.noSandbox
       })
       this.port = this.chromeInstance.port
     }
@@ -146,7 +146,7 @@ module.exports = HeadlessChrome
  *    @property {string} userDataDir - The userDataDir used by the Chrome instance
  *    @property {async fn} kill - Fn to kill the Chrome instance
  */
-async function _launchChrome ({ headless = true, disableGPU = true, port = 0, userDataDir, launchAttempts, handleSIGINT }) {
+async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = false, port = 0, userDataDir, launchAttempts, handleSIGINT }) {
   debug(`Launching Chrome instance. Headless: ${headless === true ? 'YES' : 'NO'}`)
 
   const chromeOptions = {
@@ -156,7 +156,8 @@ async function _launchChrome ({ headless = true, disableGPU = true, port = 0, us
     chromeFlags: [
       disableGPU ? '--disable-gpu' : '',
       '--enable-logging',
-      headless ? '--headless' : ''
+      headless ? '--headless' : '',
+      noSandbox ? '--no-sandbox' : ''
     ]
   }
   let attempt = 0

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -154,10 +154,10 @@ async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = 
     handleSIGINT: handleSIGINT,
     userDataDir: userDataDir,
     chromeFlags: [
-      disableGPU ? '--disable-gpu' : '',
+      disableGPU === true ? '--disable-gpu' : '',
       '--enable-logging',
-      headless ? '--headless' : '',
-      noSandbox ? '--no-sandbox' : ''
+      headless === true ? '--headless' : '',
+      noSandbox === true ? '--no-sandbox' : ''
     ]
   }
   let attempt = 0

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -156,9 +156,9 @@ async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = 
     chromeFlags: ['--enable-logging']
   }
 
-  if(disableGPU) { chromeOptions.chromeFlags.push('--disable-gpu')}
-  if(headless) { chromeOptions.chromeFlags.push('--headless')}
-  if(noSandbox) { chromeOptions.chromeFlags.push('--no-sandbox')}
+  if(disableGPU) { chromeOptions.chromeFlags.push('--disable-gpu') }
+  if(headless) { chromeOptions.chromeFlags.push('--headless') }
+  if(noSandbox) { chromeOptions.chromeFlags.push('--no-sandbox') }
 
   let attempt = 0
   let instance

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -32,7 +32,8 @@ const defaultOptions = {
     remote: false,
     launchAttempts: 3,
     userDataDir: null,
-    handleSIGINT: true
+    handleSIGINT: true,
+    noSandbox: false
   },
   loadPageTimeout: 60000,
   loadSelectorInterval: 500,
@@ -68,9 +69,10 @@ class HeadlessChrome extends EventEmitter {
         headless: this.options.headless,
         disableGPU: this.options.disableGPU,
         port: this.options.chrome.port,
-        userDataDir: this.options.chrome.userDataDir,
+        userDataDir: this.options.chrome.userDataDir,        
         launchAttempts: this.options.chrome.launchAttempts,
-        handleSIGINT: this.options.chrome.handleSIGINT
+        handleSIGINT: this.options.chrome.handleSIGINT,
+        noSandbox: this.options.chrome.noSandbox
       })
       this.port = this.chromeInstance.port
     }

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -153,13 +153,13 @@ async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = 
     port: port,
     handleSIGINT: handleSIGINT,
     userDataDir: userDataDir,
-    chromeFlags: [
-      disableGPU === true ? '--disable-gpu' : '',
-      '--enable-logging',
-      headless === true ? '--headless' : '',
-      noSandbox === true ? '--no-sandbox' : ''
-    ]
+    chromeFlags: ['--enable-logging']
   }
+
+  if(disableGPU) { chromeOptions.chromeFlags.push('--disable-gpu')}
+  if(headless) { chromeOptions.chromeFlags.push('--headless')}
+  if(noSandbox) { chromeOptions.chromeFlags.push('--no-sandbox')}
+
   let attempt = 0
   let instance
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,6 +1368,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.0.tgz#00bc5b88fd23b8130f9f5049071c3420e07a5465"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"


### PR DESCRIPTION
# Problem

* When running Headless Chrome on Linux systems, it's possible that Chrome won't be able to start because of something to do with sandboxing.

* I've observed this issue on the latest version of CentOS 7 with the latest Kernel.

# Solution

* Pass through the `--no-sandbox` flag to Chrome. This fixes the issue.
