### PR TITLE
Chrome flags

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -33,6 +33,7 @@ const defaultOptions = {
     launchAttempts: 3,
     userDataDir: null,
     handleSIGINT: true,
+    flags: ['--enable-logging'],
     noSandbox: false
   },
   loadPageTimeout: 60000,
@@ -72,6 +73,7 @@ class HeadlessChrome extends EventEmitter {
         port: this.options.chrome.port,
         userDataDir: this.options.chrome.userDataDir,
         launchAttempts: this.options.chrome.launchAttempts,
+        chromeFlags: this.options.chrome.flags,
         handleSIGINT: this.options.chrome.handleSIGINT
       })
       this.port = this.chromeInstance.port
@@ -146,14 +148,14 @@ module.exports = HeadlessChrome
  *    @property {string} userDataDir - The userDataDir used by the Chrome instance
  *    @property {async fn} kill - Fn to kill the Chrome instance
  */
-async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = false, port = 0, userDataDir, launchAttempts, handleSIGINT }) {
+async function _launchChrome ({ headless = true, disableGPU = true, noSandbox = false, port = 0, userDataDir, launchAttempts, handleSIGINT, chromeFlags }) {
   debug(`Launching Chrome instance. Headless: ${headless === true ? 'YES' : 'NO'}`)
 
   const chromeOptions = {
     port: port,
     handleSIGINT: handleSIGINT,
     userDataDir: userDataDir,
-    chromeFlags: ['--enable-logging']
+    chromeFlags: chromeFlags
   }
 
   if(disableGPU) { chromeOptions.chromeFlags.push('--disable-gpu') }


### PR DESCRIPTION
Sometimes we need to pass extra flags to chrome initialization and this should not be hardcoded.
With this PR we can pass flags at initialization level:
```js
  const browser = new HeadlessChrome({
    headless: false, // If you turn this off, you can actually see the browser navigate with your instructions
    chrome: {
      flags: [
        '--use-fake-device-for-media-stream',
        '--use-fake-ui-for-media-stream'
      ]
    }
  })
```