### PR TITLE
Add certificate override option to goTo

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -107,6 +107,17 @@ exports.goTo = async function (url, opt = {}) {
     timeout: this.options.browser.loadPageTimeout
   }, opt)
 
+  if (options.bypassCertificate) {
+    this.client.Security.certificateError(({eventId}) => {
+      this.client.Security.handleCertificateError({
+        eventId,
+        action: 'continue'
+      });
+    });
+
+    this.client.Security.setOverrideCertificateErrors({override: true});
+  }
+
   await this.client.Page.navigate({ url })
 
   if (options.timeout && typeof options.timeout) {

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -111,7 +111,8 @@ module.exports.attachCdpToTarget = async function (host, port, targetId) {
       client.Network.enable(),
       client.Page.enable(),
       client.DOM.enable(),
-      client.CSS.enable()
+      client.CSS.enable(),
+      client.Security.enable()
     ])
 
     debug(`CDP prepared for tab "${targetId}"!`)


### PR DESCRIPTION
This adds "bypassCertificate" as an option to goTo.

You only need it the first time you use goTo on a domain that will trigger a certificate warning.  Subsequent goTo calls will work fine.